### PR TITLE
Feature/boto no proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Full list of options in `config.json`:
 | adjust_timestamps                   | Boolean |            | (Default: True) When set to false, bypasses the checking of timestamp and time values and setting them to the MAX values in Snowflake. This is useful if incoming data values are definitely date/time/datetime values and no parse testing is required.
 | archive_load_files_s3_prefix        | String  |            | (Default: "archive") When `archive_load_files` is enabled, the archived files will be placed in the archive S3 bucket under this prefix.
 | archive_load_files_s3_bucket        | String  |            | (Default: Value of `s3_bucket`) When `archive_load_files` is enabled, the archived files will be placed in this bucket.
+| s3_proxies        | Object  | No           | (Default: None) If not set then http_proxy and https_proxy and other environmental settings will dictate which proxy is used. If this is set then you can specify a proxy for the S3 Upload connection to use, or set to `{}` to force the S3 Uploader to bypass a proxy entirely
 
 ### To run tests:
 

--- a/target_snowflake/upload_clients/s3_upload_client.py
+++ b/target_snowflake/upload_clients/s3_upload_client.py
@@ -5,7 +5,6 @@ import os
 import boto3
 from botocore.config import Config
 import datetime
-import json
 
 from snowflake.connector.encryption_util import SnowflakeEncryptionUtil
 from snowflake.connector.storage_client import SnowflakeFileEncryptionMaterial

--- a/target_snowflake/upload_clients/s3_upload_client.py
+++ b/target_snowflake/upload_clients/s3_upload_client.py
@@ -53,7 +53,7 @@ class S3UploadClient(BaseUploadClient):
             s3_client = aws_session.client('s3',
                                   region_name=config.get('s3_region_name'),
                                   endpoint_url=config.get('s3_endpoint_url'),
-                                  config=Config(proxies=json.loads(s3_proxies))
+                                  config=Config(proxies=s3_proxies)
                                           )
         return s3_client
 

--- a/target_snowflake/upload_clients/s3_upload_client.py
+++ b/target_snowflake/upload_clients/s3_upload_client.py
@@ -5,6 +5,7 @@ import os
 import boto3
 from botocore.config import Config
 import datetime
+import json
 
 from snowflake.connector.encryption_util import SnowflakeEncryptionUtil
 from snowflake.connector.storage_client import SnowflakeFileEncryptionMaterial
@@ -49,14 +50,10 @@ class S3UploadClient(BaseUploadClient):
                                   endpoint_url=config.get('s3_endpoint_url'),
                                           )
         else:
-            if s3_proxies == "{}":
-                s3_proxies = {}
-            else:
-                s3_proxies = dict(s3_proxies)
             s3_client = aws_session.client('s3',
                                   region_name=config.get('s3_region_name'),
                                   endpoint_url=config.get('s3_endpoint_url'),
-                                  config=Config(proxies=dict(s3_proxies))
+                                  config=Config(proxies=json.loads(s3_proxies))
                                           )
         return s3_client
 


### PR DESCRIPTION
## Problem

It was not previously possible to independently set the no_proxy flag on the S3 connections, so all connections in our environment were going from AWS ECS to AWS S3 via an unnecessary proxy 'hop'

## Proposed changes

Add a new configuration option called `s3_proxies` which is passed directly to the `proxies` argument of `botocore.config.Config`. The setting must be a `dict` object. If you are using `meltano.yml` you must have:

```yaml
settings:
  - name: s3_proxies
    kind: object
```

If this is not set, then it will simply pick up whatever is in `http_proxy`, `https_proxy` environment variables as before.

To force the s3 to bypass the proxy (as we will be doing), set `s3_proxies` to an empty `dict`:
```
s3_proxies = {}
```

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions