### PR TITLE
Set _sdc_deleted_at to date-time in the schema message

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -47,7 +47,8 @@ def add_metadata_columns_to_schema(schema_message):
                                                                             'format': 'date-time'}
     extended_schema_message['schema']['properties']['_sdc_batched_at'] = {'type': ['null', 'string'],
                                                                           'format': 'date-time'}
-    extended_schema_message['schema']['properties']['_sdc_deleted_at'] = {'type': ['null', 'string']}
+    extended_schema_message['schema']['properties']['_sdc_deleted_at'] = {'type': ['null', 'string'],
+                                                                          'format': 'date-time'}
 
     return extended_schema_message
 


### PR DESCRIPTION
## Problem

The `_sdc_deleted_at` column on the target snowflake comes through as `TEXT` format in Snowflake

## Proposed changes

Set the `_sdc_deleted_at` format as `date-time`, which will set the column up as `TIMESTAMP_NTZ` in Snowflake


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions