### PR TITLE
Feature/truncate drop option

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -34,7 +34,6 @@ logging.getLogger('snowflake.connector').setLevel(logging.WARNING)
 DEFAULT_BATCH_SIZE_ROWS = 100000
 DEFAULT_PARALLELISM = 0  # 0 The number of threads used to flush tables
 DEFAULT_MAX_PARALLELISM = 16  # Don't use more than this number of threads by default when flushing streams in parallel
-DEFAULT_REPLICATION_METHOD = 'append'
 
 
 def add_metadata_columns_to_schema(schema_message):

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -34,6 +34,7 @@ logging.getLogger('snowflake.connector').setLevel(logging.WARNING)
 DEFAULT_BATCH_SIZE_ROWS = 100000
 DEFAULT_PARALLELISM = 0  # 0 The number of threads used to flush tables
 DEFAULT_MAX_PARALLELISM = 16  # Don't use more than this number of threads by default when flushing streams in parallel
+DEFAULT_REPLICATION_METHOD = 'append'
 
 
 def add_metadata_columns_to_schema(schema_message):
@@ -308,6 +309,8 @@ def persist_lines(config, lines, table_cache=None, file_format_type: FileFormatT
                         )
 
                 stream_to_sync[stream].create_schema_if_not_exists()
+                if config.get('replication_method') == 'truncate':
+                    stream_to_sync[stream].truncate_table()
                 stream_to_sync[stream].sync_table()
 
                 row_count[stream] = 0

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -309,8 +309,6 @@ def persist_lines(config, lines, table_cache=None, file_format_type: FileFormatT
                         )
 
                 stream_to_sync[stream].create_schema_if_not_exists()
-                if config.get('replication_method') == 'truncate':
-                    stream_to_sync[stream].truncate_table()
                 stream_to_sync[stream].sync_table()
 
                 row_count[stream] = 0

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -67,6 +67,10 @@ def validate_config(config):
     if archive_load_files and not config.get('s3_bucket', None):
         errors.append('Archive load files option can be used only with external s3 stages. Please define s3_bucket.')
 
+    replication_method = config.get('replication_method','append')
+    if replication_method not in ['append','truncate']:
+        errors.append(f'Unrecognised replication_method: {replication_method} - valid values are append, truncate')
+
     return errors
 
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -808,12 +808,6 @@ class DbSync:
         self.logger.info('Adding column: %s', add_column)
         self.query(add_column)
 
-    def truncate_table(self):
-        """Truncates the table of all rows"""
-        truncate_table = f"TRUNCATE TABLE {self.table_name(stream, False)}"
-        self.logger.info(f"Truncating table: {self.table_name(stream, False)}")
-        self.query(truncate_table)
-
     def sync_table(self):
         """Creates or alters the target table according to the schema"""
         stream_schema_message = self.stream_schema_message
@@ -840,6 +834,9 @@ class DbSync:
                 self.table_cache = self.get_table_columns(table_schemas=[self.schema_name])
         else:
             self.logger.info('Table %s exists', table_name_with_schema)
+            if self.connection_config.get('replication_method') == 'truncate':
+                self.logger.info('Truncating table: %s', table_name_with_schema)
+                self.query(f"TRUNCATE TABLE {table_name_with_schema}")
             self.update_columns()
 
         self._refresh_table_pks()

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -808,6 +808,12 @@ class DbSync:
         self.logger.info('Adding column: %s', add_column)
         self.query(add_column)
 
+    def truncate_table(self):
+        """Truncates the table of all rows"""
+        truncate_table = f"TRUNCATE TABLE {self.table_name(stream, False)}"
+        self.logger.info(f"Truncating table: {self.table_name(stream, False)}")
+        self.query(truncate_table)
+
     def sync_table(self):
         """Creates or alters the target table according to the schema"""
         stream_schema_message = self.stream_schema_message


### PR DESCRIPTION
## Problem

To echo the functionality of another product, we require `target-snowflake` to have the capability to truncate the target table before the loading commences.

## Proposed changes

The addition of `replication_method` config option which allows user to specify `"truncate"` which will truncate the target table before the load.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions