### PR TITLE
Feat/set dtype object in pandas data frame

### DIFF
--- a/target_snowflake/file_formats/parquet.py
+++ b/target_snowflake/file_formats/parquet.py
@@ -66,7 +66,10 @@ def records_to_dataframe(records: Dict,
         flatten_record = flattening.flatten_record(record, schema, max_level=data_flattening_max_level)
         flattened_records.append(flatten_record)
 
-    return pandas.DataFrame(data=flattened_records, dtype='object',)
+    return pandas.DataFrame(
+              data=flattened_records,
+              dtype='object',
+            )
 
 
 def records_to_file(records: Dict,

--- a/target_snowflake/file_formats/parquet.py
+++ b/target_snowflake/file_formats/parquet.py
@@ -66,7 +66,7 @@ def records_to_dataframe(records: Dict,
         flatten_record = flattening.flatten_record(record, schema, max_level=data_flattening_max_level)
         flattened_records.append(flatten_record)
 
-    return pandas.DataFrame(data=flattened_records)
+    return pandas.DataFrame(data=flattened_records, dtype='object',)
 
 
 def records_to_file(records: Dict,

--- a/tests/unit/file_formats/test_parquet.py
+++ b/tests/unit/file_formats/test_parquet.py
@@ -48,7 +48,33 @@ class TestParquet(unittest.TestCase):
                                'key3': ['10000-01-22 12:04:22', '10000-01-22 12:04:22', '10000-01-22 12:04:22'],
                                'key4': ['12:01:01', '13:01:01', '14:01:01'],
                                'key5': ['I\'m good', 'I\'m good too', 'I want to be good'],
-                               'key6': [None, None, None]}))
+                               'key6': [None, None, None]},
+                               dtype='object',
+                              ),
+                            )
+    
+    def test_large_integer(self):
+        """Specific test for dataframes checking that integer values are reproduced exactly."""
+        
+        # Create a test record of a large integer and a null in the same key
+        large_integer = 9223372036854775807
+        
+        test_records = {
+                        '1':
+                          {
+                            'key1':large_integer
+                          },
+                        '2':
+                          {
+                            'key1':None
+                          },
+                        }
+        
+        # Ensure that the large integer is not equal to itself minus 1
+        self.assertNotEqual(
+          large_integer-1
+          ,parquet.records_to_dataframe(records=test_records, schema={})['key1'][0]
+        )
 
     def test_create_copy_sql(self):
         self.assertEqual(parquet.create_copy_sql(table_name='foo_table',


### PR DESCRIPTION
## Problem

Issue details here: https://github.com/transferwise/pipelinewise-target-snowflake/issues/404

## Proposed changes

Use `dtype=object` argument for `DataFrame` in `file_formats.parquet.records_to_dataframe` to preserve Python types and precision on large numeric values.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions